### PR TITLE
Bugfix/face detector all points contour ios

### DIFF
--- a/ios/Classes/FaceDetector.m
+++ b/ios/Classes/FaceDetector.m
@@ -135,7 +135,8 @@
   return [NSNull null];
 }
 
-// Order based on ML Kit doc https://developers.google.com/ml-kit/vision/face-detection/face-detection-concepts#contours
+// Order based on ML Kit constant orders https://developers.google.com/android/reference/com/google/mlkit/vision/face/FaceContour
+// Order from ML Kit documentation is not valid for lips https://developers.google.com/ml-kit/vision/face-detection/face-detection-concepts#contours
 + (id)getAllContourPoints:(MLKFace *)face {
     NSMutableArray *result = [[NSMutableArray alloc] init];
     
@@ -146,9 +147,9 @@
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeRightEyebrowBottom]];
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLeftEye]];
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeRightEye]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeUpperLipTop]];
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeUpperLipBottom]];
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLowerLipTop]];
-    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeUpperLipTop]];
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLowerLipBottom]];
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeNoseBridge]];
     [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeNoseBottom]];

--- a/ios/Classes/FaceDetector.m
+++ b/ios/Classes/FaceDetector.m
@@ -135,18 +135,27 @@
   return [NSNull null];
 }
 
+// Order based on ML Kit doc https://developers.google.com/ml-kit/vision/face-detection/face-detection-concepts#contours
 + (id)getAllContourPoints:(MLKFace *)face {
-  NSArray<MLKFaceContour *> *contours = [face contours];
     NSMutableArray *result = [[NSMutableArray alloc] init];
-    for (int i = 0; i < [contours count]; i++) {
-        NSArray<MLKVisionPoint *> *contourPoints = contours[i].points;
-        for (int j = 0; j < [contourPoints count]; j++) {
-          MLKVisionPoint *point = [contourPoints objectAtIndex:j];
-          [result addObject:@[ @(point.x), @(point.y) ] ];
-        }
-        
-    }
-   return [result copy];
+    
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeFace]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLeftEyebrowTop]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLeftEyebrowBottom]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeRightEyebrowTop]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeRightEyebrowBottom]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLeftEye]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeRightEye]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeUpperLipBottom]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLowerLipTop]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeUpperLipTop]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLowerLipBottom]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeNoseBridge]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeNoseBottom]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeLeftCheek]];
+    [result addObjectsFromArray:[FaceDetector getContourPoints:face contour:MLKFaceContourTypeRightCheek]];
+
+    return [result copy];
 }
 
 + (MLKFaceDetectorOptions *)parseOptions:(NSDictionary *)optionsData {


### PR DESCRIPTION
Tried to use order from [ML Kit documentation](https://developers.google.com/ml-kit/vision/face-detection/face-detection-concepts#contours) but it has wrong lips position. Instead I used order based on Android SDK [FaceContour](https://developers.google.com/android/reference/com/google/mlkit/vision/face/FaceContour) constant values and now both iOS & Android contour positions are perfectly aligned.

Issue:
https://github.com/brianmtully/flutter_google_ml_vision/issues/14